### PR TITLE
Update to 'sustained disruption' to cover slack

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -20,7 +20,7 @@ Here are a few examples of unacceptable behavior:
 
 * Touching people without their affirmative consent.
 
-* Sustained and negative disruption of meetings or talks.
+* Sustained disruption of meetings, talks, or discussions, including chatrooms.
 
 * Patronizing language or behavior.
 


### PR DESCRIPTION
Updating the 'sustained disruptions' line to make it clear that sustained disruption of chat channels is not acceptable (even if those disruptions are not meant to be negative--for instance, constantly spamming a project channel with funny but off-topic gifs).